### PR TITLE
Title feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ var welcomescreen_slides = [
   {
     id: 'slide0',
     picture: '<div class="tutorialicon">♥</div>',
+    title: 'Welcomescreen intro',
     text: 'Welcome to this tutorial. In the next steps we will guide you through a manual that will teach you how to use this app.'
   },
   {
     id: 'slide1',
     picture: '<div class="tutorialicon">✲</div>',
+    title: 'This is title 2',
     text: 'This is slide 2'
   },
   {

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Parameters
 
 - *id* Set an id for this slide
 - *picture* Set free html here
+- *title* Set a text or html of slide title here (optional)
 - *text* You *can* set html here but I recommend using just plain text
 
 3) Initialize & options

--- a/example/js/myapp/pages/IndexPageController.js
+++ b/example/js/myapp/pages/IndexPageController.js
@@ -23,11 +23,13 @@ myapp.pages.IndexPageController = function (myapp, $$) {
       {
         id: 'slide0',
         picture: '<div class="tutorialicon">♥</div>',
+        title: 'Welcomescreen intro',
         text: 'Welcome to this tutorial. In the <a class="tutorial-next-link" href="#">next steps</a> we will guide you through a manual that will teach you how to use this app.'
       },
       {
         id: 'slide1',
         picture: '<div class="tutorialicon">✲</div>',
+        title: 'This is title 2',
         text: 'This is slide 2'
       },
       {

--- a/welcomescreen.css
+++ b/welcomescreen.css
@@ -32,6 +32,18 @@
   margin-top: 30%;
 }
 
+.welcomescreen-title {
+  position:absolute;
+  bottom: 140px;
+  left: 0;
+  right: 0;
+  padding-left: 20px;
+  padding-right: 20px;
+  text-align:center;
+  font-size: x-large;
+  font-weight: 700;
+}
+
 .welcomescreen-text {
   position:absolute;
   bottom: 65px;

--- a/welcomescreen.js
+++ b/welcomescreen.js
@@ -21,7 +21,6 @@ Framework7.prototype.plugins.welcomescreen = function (app, globalPluginParams) 
     var $wscreen = $$(this).parents('.welcomescreen-container');
     if ($wscreen.length > 0 && $wscreen[0].f7Welcomescreen) { $wscreen[0].f7Welcomescreen.close(); }
   });
-  
   /**
    * Represents the welcome screen
    *
@@ -92,6 +91,9 @@ Framework7.prototype.plugins.welcomescreen = function (app, globalPluginParams) 
                 '{{else}}' +
                   '{{#if picture}}' +
                     '<div class="welcomescreen-picture">{{picture}}</div>' +
+                  '{{/if}}' +
+                  '{{#if title}}' +
+                    '<div class="welcomescreen-title">{{title}}</div>'+
                   '{{/if}}' +
                   '{{#if text}}' +
                     '<div class="welcomescreen-text">{{text}}</div>' +


### PR DESCRIPTION
Adds another line to the template to allow for a title. The title can be set using the `title` key in a object. I also changed the example in both the `example` folder and in `README.md` to reflect this change. Also this is my first pull request so let me know if you need anything changed. 
![This is what it looks like](https://cloud.githubusercontent.com/assets/885544/20417156/818ec916-ad11-11e6-9217-c50a59e863f5.png)
